### PR TITLE
Feature: filter by aspect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>org.redpill-linpro.alfresco.numbering</groupId>
   <artifactId>alfresco-numbering</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1-SNAPSHOT</version>
   <name>Alfresco Numbering</name>
   <packaging>pom</packaging>
   <properties>
@@ -52,6 +52,18 @@
     <url>https://github.com/Redpill-Linpro/alfresco-numbering/issues</url>
   </issueManagement>
   <repositories>
+    <repository>
+      <id>alfresco-public</id>
+      <url>https://artifacts.alfresco.com/nexus/content/groups/public</url>
+    </repository>
+    <repository>
+      <id>alfresco-public-snapshots</id>
+      <url>https://artifacts.alfresco.com/nexus/content/groups/public-snapshots</url>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>daily</updatePolicy>
+      </snapshots>
+    </repository>
     <repository>
       <id>redpill-public</id>
       <url>https://maven.redpill-linpro.com/nexus/content/groups/public</url>

--- a/repo/pom.xml
+++ b/repo/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.redpill-linpro.alfresco.numbering</groupId>
     <artifactId>alfresco-numbering</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1-SNAPSHOT</version>
   </parent>
   <artifactId>alfresco-numbering-repo</artifactId>
   <packaging>jar</packaging>
@@ -54,6 +54,12 @@
       <artifactId>alfresco-test-repo</artifactId>
       <version>1.0.16</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>

--- a/repo/src/main/java/org/redpill/alfresco/numbering/component/NumberingComponentImpl.java
+++ b/repo/src/main/java/org/redpill/alfresco/numbering/component/NumberingComponentImpl.java
@@ -35,11 +35,13 @@ public class NumberingComponentImpl implements NumberingComponent, InitializingB
 
   protected long startValue = 1;
   protected List<String> bindTypes = new ArrayList<>();
+  protected List<String> bindAspects = new ArrayList<>();
   protected List<String> ignoreTypes = new ArrayList<>();
   protected List<String> ignoreAspects = new ArrayList<>();
   protected List<QName> bindTypeQNames = new ArrayList<>();
   protected List<QName> ignoreTypeQNames = new ArrayList<>();
   protected List<QName> ignoreAspectQNames = new ArrayList<>();
+    protected List<QName>bindAspectQNames = new ArrayList<>();
   protected Decorator decorator;
   protected NamespaceService namespaceService;
 
@@ -74,6 +76,21 @@ public class NumberingComponentImpl implements NumberingComponent, InitializingB
       return false;
     }
 
+    // If list bindAspectQNames is not empty, check that the node is of allowed aspect
+    if (!bindAspectQNames.isEmpty()) {
+      boolean aspectMatch = false;
+      for (QName bindAspect : bindAspectQNames) {
+          if(nodeService.hasAspect(nodeRef, bindAspect)) {
+              aspectMatch = true;
+          }
+      }
+      if (!aspectMatch) {
+          if(LOG.isTraceEnabled())  {
+              LOG.trace("Node " + nodeRef + " is not in the list of allowed aspects ");
+          }
+          return false;
+      }
+    }
     //Check if the node type is on the type ignore list
     for (QName ignoreType : ignoreTypeQNames) {
       if (type.equals(ignoreType)) {
@@ -116,7 +133,6 @@ public class NumberingComponentImpl implements NumberingComponent, InitializingB
  //   assertAllowGetNextNumber(nodeRef,subOptionValue);
     return numberingStorage.getNextNumber(startValue, id,subOptionValue);
   }
-
 
  @Override
   public String getDecoratedNextNumber(final NodeRef nodeRef) {
@@ -178,6 +194,16 @@ public class NumberingComponentImpl implements NumberingComponent, InitializingB
       checkForDictionaryExistance(bindTypes, bindTypeQNames);
     }
   }
+
+    public void setBindAspects(List<String> bindAspects) {
+        this.bindAspects = bindAspects;
+        if (bindAspects != null) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Registering bind aspects: " + bindAspects.toString());
+            }
+            checkForDictionaryExistance(bindAspects, bindAspectQNames);
+        }
+    }
 
   public void setIgnoreAspects(List<String> ignoreAspects) {
     this.ignoreAspects = ignoreAspects;

--- a/repo/src/main/java/org/redpill/alfresco/numbering/decorator/BasicDecorator.java
+++ b/repo/src/main/java/org/redpill/alfresco/numbering/decorator/BasicDecorator.java
@@ -1,7 +1,7 @@
 package org.redpill.alfresco.numbering.decorator;
 
 import org.alfresco.service.cmr.repository.NodeRef;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * A regular number series


### PR DESCRIPTION
The current implementation does not allow to filter by aspect.
This implementation lets you do that, you will still have to specify content type, but that can be cm:content if you only want to filter by the aspect (since all content is cm:content or subtype).

Also included in this is a change to commons-lang3 to support Alfresco 7+